### PR TITLE
RNG for fuzz seed

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8140,6 +8140,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     std::string FuzzSeedArgStr = "-fuzz-seed=";
     const char *FuzzSeedArg = Args.MakeArgStringRef(FuzzSeedArgStr + StrSeed);
     CmdArgs.push_back(FuzzSeedArg);
+
+    // Specify rng seed when in fuzzing mode.
+    // Machine basic block shuffling algorithm relies on llvm rng instead of fuzz seed for implementation reasons.
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back(Args.MakeArgString("-rng-seed=" + StrSeed));
   }
 
   if (D.CC1Main && !D.CCGenDiagnostics) {

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -978,6 +978,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addMachinePasses(
 
   if (ForceBlockShuffling || isFuzzed(fuzz::BPU, NumBlockShufflingEntry) || isFuzzed(fuzz::L1I, NumBlockShufflingEntry))
     derived().addBlockShuffling(addPass);
+    NumBlockShufflingEntry -= 2; // Do not increment this stat here, increment it directly in the pass instead.
 
   // Insert before XRay Instrumentation.
   addPass(FEntryInserterPass());

--- a/llvm/lib/CodeGen/MachineBlockShuffling.cpp
+++ b/llvm/lib/CodeGen/MachineBlockShuffling.cpp
@@ -134,6 +134,8 @@ bool MachineBlockShuffling::runOnMachineFunction(MachineFunction &MF) {
       return false;
     }
 
+    NumBlockShufflingEntry--; // due to double-increment in isFuzzed checks
+
     if (!RNG) {
       RNG = std::move(MF.getFunction().getParent()->createRNG("MBB_shuffling"));
     }


### PR DESCRIPTION
Added rng seed option that equals fuzz seed when it is set.

It could be required for reproducible runs. For example, machine basic block shuffling uses llvm's rng with its own seed, so this PR should synchronize two different random sourced for fuzzing mode.