### PR TITLE
L1D: Add 'l1d' fuzzing component

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6736,7 +6736,7 @@ def fuzz_EQ : Joined<["--"], "fuzz=">,
   Flags<[NoXarchOption, HelpHidden]>, Group<f_Group>,
   HelpText<"Fuzz selected compiler components, RISC-V only."
   "Usage: --fuzz=\"<component1>[|<component2>...]\"">,
-  Values<"all, scheduler, mbb-placement, regalloc, isel, alloca, bpu, l1i">;
+  Values<"all, scheduler, mbb-placement, regalloc, isel, alloca, bpu, l1i, l1d">;
 
 def fseed_EQ : Joined<["--"], "fseed=">,
   Flags<[NoXarchOption, HelpHidden]>, Group<f_Group>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8091,7 +8091,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     }
 
     llvm::SmallVector<StringRef> CorrectOpts = {
-        "all", "scheduler", "mbb-placement", "regalloc", "isel", "alloca", "bpu", "l1i"};
+        "all", "scheduler", "mbb-placement", "regalloc", "isel", "alloca", "bpu", "l1i", "l1d"};
 
     // TODO: Two following for-loops can be combined.
     for (const auto &ActualOpt : ActualOpts)

--- a/llvm/include/llvm/CompilerAssistedFuzzing/FuzzInfo.h
+++ b/llvm/include/llvm/CompilerAssistedFuzzing/FuzzInfo.h
@@ -34,6 +34,7 @@ extern Component ISel;
 extern Component Alloca;
 extern Component BPU;
 extern Component L1I;
+extern Component L1D;
 
 bool isFuzzed(fuzz::Component &Comp, llvm::TrackingStatistic &Stat);
 int64_t fuzzedIntRange(fuzz::Component &Comp, llvm::TrackingStatistic &Stat,

--- a/llvm/lib/CompilerAssistedFuzzing/FuzzInfo.cpp
+++ b/llvm/lib/CompilerAssistedFuzzing/FuzzInfo.cpp
@@ -29,9 +29,10 @@ Component fuzz::RegAlloc("regalloc");
 Component fuzz::ISel("isel");
 Component fuzz::Alloca("alloca");
 Component fuzz::L1I("l1i");
-std::array<std::reference_wrapper<Component>, 7> Components{
+Component fuzz::L1D("l1d");
+std::array<std::reference_wrapper<Component>, 8> Components{
     fuzz::Scheduler, fuzz::MBBPlacement, fuzz::RegAlloc, fuzz::ISel,
-    fuzz::Alloca, fuzz::BPU, fuzz::L1I};
+    fuzz::Alloca, fuzz::BPU, fuzz::L1I, fuzz::L1D};
 
 inline bool isCompUsed(const Component &Comp) {
   if (FuzzComponents.find("all") != std::string::npos)


### PR DESCRIPTION
This PR adds the `l1d` option for `--fuzz` flag. Usage: `--fuzz=l1d`