### PR TITLE
L1D: Extract global data to unique sections

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/GlobalDataExtraction.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalDataExtraction.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This pass extracts global data into a separate unique sections.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_IPO_GLOBALDATAEXTRACTION_H
+#define LLVM_TRANSFORMS_IPO_GLOBALDATAEXTRACTION_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class Module;
+
+class GlobalDataExtraction {
+public:
+  GlobalDataExtraction() {}
+  bool run(Module &M);
+};
+
+/// Pass to extract global data from functions.
+class GlobalDataExtractionPass : public PassInfoMixin<GlobalDataExtractionPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+} // end namespace llvm
+
+#endif // LLVM_TRANSFORMS_IPO_GLOBALDATAEXTRACTION_H
+

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -327,6 +327,7 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.h"
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
 #include "llvm/Transforms/IPO/BasicBlocksExtraction.h"
+#include "llvm/Transforms/IPO/GlobalDataExtraction.h"
 #include <optional>
 
 using namespace llvm;

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -56,6 +56,7 @@
 #include "llvm/Transforms/IPO/ExpandVariadics.h"
 #include "llvm/Transforms/IPO/ForceFunctionAttrs.h"
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
+#include "llvm/Transforms/IPO/GlobalDataExtraction.h"
 #include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/IPO/GlobalOpt.h"
 #include "llvm/Transforms/IPO/GlobalSplit.h"
@@ -152,6 +153,8 @@ using namespace llvm;
 
 ALWAYS_ENABLED_STATISTIC(BBExtractionRegisterFuzzStat,
                          "Basic block extraction pass register.");
+ALWAYS_ENABLED_STATISTIC(GlobalDataExtractionRegisterFuzzStat,
+                         "Global data extraction pass register.");
 
 static cl::opt<InliningAdvisorMode> UseInlineAdvisor(
     "enable-ml-inliner", cl::init(InliningAdvisorMode::Default), cl::Hidden,
@@ -1560,6 +1563,10 @@ PassBuilder::buildModuleOptimizationPipeline(OptimizationLevel Level,
   // L1I caches fuzzing pass
   if (isFuzzed(fuzz::L1I, BBExtractionRegisterFuzzStat))
     MPM.addPass(BasicBlocksExtractionPass());
+
+  // L1D caches fuzzing passes
+  if (isFuzzed(fuzz::L1D, GlobalDataExtractionRegisterFuzzStat))
+    MPM.addPass(GlobalDataExtractionPass());
 
   // Search the code for similar regions of code. If enough similar regions can
   // be found where extracting the regions into their own function will decrease

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -76,6 +76,7 @@ MODULE_PASS("hipstdpar-select-accelerator-code",
             HipStdParAcceleratorCodeSelectionPass())
 MODULE_PASS("hotcoldsplit", HotColdSplittingPass())
 MODULE_PASS("basicblockextraction", BasicBlocksExtractionPass())
+MODULE_PASS("globaldataextraction", GlobalDataExtractionPass())
 MODULE_PASS("inferattrs", InferFunctionAttrsPass())
 MODULE_PASS("inliner-ml-advisor-release",
             ModuleInlinerWrapperPass(getInlineParams(), true, {},

--- a/llvm/lib/Transforms/IPO/BasicBlocksExtraction.cpp
+++ b/llvm/lib/Transforms/IPO/BasicBlocksExtraction.cpp
@@ -370,6 +370,17 @@ bool BasicBlocksExtraction::run(Module &M) {
     LLVM_DEBUG(llvm::dbgs() << "Outlining in " << F.getName() << "\n");
     Changed |= outlineRegions(F);
   }
+
+  unsigned long SectionsCount = 1;
+  for (auto &G : M.globals()) {
+    if (!G.getSection().empty()) // Don't modify unique sections
+      continue;
+    if (G.getLinkage() != GlobalValue::LinkageTypes::ExternalLinkage)
+      continue;
+    G.setSection(".globalVariable.fuzz" + std::to_string(SectionsCount));
+    SectionsCount++;
+  }
+
   return Changed;
 }
 

--- a/llvm/lib/Transforms/IPO/CMakeLists.txt
+++ b/llvm/lib/Transforms/IPO/CMakeLists.txt
@@ -23,6 +23,7 @@ add_llvm_component_library(LLVMipo
   GlobalSplit.cpp
   HotColdSplitting.cpp
   BasicBlocksExtraction.cpp
+  GlobalDataExtraction.cpp
   IPO.cpp
   IROutliner.cpp
   InferFunctionAttrs.cpp

--- a/llvm/lib/Transforms/IPO/GlobalDataExtraction.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalDataExtraction.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This pass extracts global data into a unique separate sections (if no other
+/// section is provided already). Section names are: .globalVariable.fuzz1,
+/// .globalVariable.fuzz2, etc.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/IPO/GlobalDataExtraction.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/Analysis/PostDominators.h"
+#include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/CompilerAssistedFuzzing/FuzzInfo.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/EHPersonalities.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/ProfDataUtils.h"
+#include "llvm/IR/User.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/Utils/CodeExtractor.h"
+#include <algorithm>
+#include <cassert>
+#include <limits>
+#include <string>
+
+#define DEBUG_TYPE "globaldataextraction"
+
+using namespace llvm;
+
+bool GlobalDataExtraction::run(Module &M) {
+  bool Changed = false;
+
+  unsigned long SectionsCount = 1;
+  for (auto &G : M.globals()) {
+    if (!G.getSection().empty()) // Don't modify unique sections
+      continue;
+    if (G.getLinkage() != GlobalValue::LinkageTypes::ExternalLinkage)
+      continue;
+    G.setSection(".globalVariable.fuzz" + std::to_string(SectionsCount));
+    SectionsCount++;
+    Changed = true;
+  }
+
+  return Changed;
+}
+
+PreservedAnalyses
+GlobalDataExtractionPass::run(Module &M, ModuleAnalysisManager &AM) {
+  if (GlobalDataExtraction().run(M))
+    return PreservedAnalyses::none();
+  return PreservedAnalyses::all();
+}


### PR DESCRIPTION
This PR extracts global data to unique sections (if there isn't any already!), namely: `.globalVariable.fuzz1`, `.globalVariable.fuzz2`, etc. I created very small separate pass for this purpose